### PR TITLE
Bump underscore from 1.12.0 to 1.13.1 in /demoapp

### DIFF
--- a/demoapp/package-lock.json
+++ b/demoapp/package-lock.json
@@ -603,9 +603,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
-      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "universalify": {
       "version": "1.0.0",


### PR DESCRIPTION
Duplicated PR to #32 which doesn't have access to Actions

Bumps [underscore](https://github.com/jashkenas/underscore) from 1.12.0 to 1.13.1.
- [Release notes](https://github.com/jashkenas/underscore/releases)
- [Commits](https://github.com/jashkenas/underscore/compare/1.12.0...1.13.1)

Signed-off-by: dependabot[bot] <support@github.com>